### PR TITLE
#42 DDL 수정

### DIFF
--- a/order-server/src/main/java/com/inbobwetrust/model/entitiy/Order.java
+++ b/order-server/src/main/java/com/inbobwetrust/model/entitiy/Order.java
@@ -17,6 +17,8 @@ public class Order {
 
     private Long shopId;
 
+    private Long deliveryId;
+
     private OrderStatus orderStatus;
 
     private String address;
@@ -32,6 +34,7 @@ public class Order {
             Long id,
             Long customerId,
             Long shopId,
+            Long deliveryId,
             OrderStatus orderStatus,
             String address,
             String phoneNumber,
@@ -40,6 +43,7 @@ public class Order {
         this.id = id;
         this.customerId = customerId;
         this.shopId = shopId;
+        this.deliveryId = deliveryId;
         this.orderStatus = orderStatus;
         this.address = address;
         this.phoneNumber = phoneNumber;

--- a/order-server/src/main/java/com/inbobwetrust/model/entitiy/Shop.java
+++ b/order-server/src/main/java/com/inbobwetrust/model/entitiy/Shop.java
@@ -9,12 +9,12 @@ import lombok.ToString;
 @ToString
 @NoArgsConstructor
 public class Shop {
-    private String id;
+    private Long id;
 
     private String endpoint;
 
     @Builder
-    public Shop(String id, String endpoint) {
+    public Shop(Long id, String endpoint) {
         this.id = id;
         this.endpoint = endpoint;
     }

--- a/order-server/src/main/resources/schema.sql
+++ b/order-server/src/main/resources/schema.sql
@@ -1,102 +1,62 @@
-CREATE SCHEMA IF NOT EXISTS `order_server` DEFAULT CHARACTER SET utf8 ;
-USE `order_server` ;
-
 -- -----------------------------------------------------
--- Table `tbl_agency`
+-- Table tbl_agency
 -- -----------------------------------------------------
-CREATE TABLE IF NOT EXISTS `tbl_agency` (
-  `id` BIGINT(20) GENERATED ALWAYS AS (),
-  `endpoint` VARCHAR(300) NOT NULL,
-  PRIMARY KEY (`id`),
-  UNIQUE INDEX `id_UNIQUE` (`id` ASC) VISIBLE)
-
-
+CREATE TABLE IF NOT EXISTS tbl_agency (
+  id BIGINT(20) NOT NULL AUTO_INCREMENT,
+  endpoint VARCHAR(300) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE (id)
+);
 -- -----------------------------------------------------
--- Table `tbl_shop`
+-- Table tbl_shop
 -- -----------------------------------------------------
-CREATE TABLE IF NOT EXISTS `tbl_shop` (
-  `id` BIGINT(20) GENERATED ALWAYS AS (),
-  `endpoint` VARCHAR(300) NOT NULL,
-  PRIMARY KEY (`id`),
-  UNIQUE INDEX `id_UNIQUE` (`id` ASC) VISIBLE)
-
+CREATE TABLE IF NOT EXISTS tbl_shop (
+  id BIGINT(20) NOT NULL AUTO_INCREMENT,
+  endpoint VARCHAR(300) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE (id)
+);
 -- -----------------------------------------------------
--- Table `tbl_rider`
+-- Table tbl_rider
 -- -----------------------------------------------------
-CREATE TABLE IF NOT EXISTS `tbl_rider` (
-  `id` BIGINT(20) GENERATED ALWAYS AS (),
-  `agency_id` BIGINT(20) NOT NULL,
-  INDEX `fk_table1_tbl_agency_idx` (`agency_id` ASC) VISIBLE,
-  PRIMARY KEY (`id`),
-  UNIQUE INDEX `id_UNIQUE` (`id` ASC) VISIBLE,
-  CONSTRAINT `fk_table1_tbl_agency`
-    FOREIGN KEY (`agency_id`)
-    REFERENCES `tbl_agency` (`id`)
-    ON DELETE NO ACTION
-    ON UPDATE NO ACTION)
-
+CREATE TABLE IF NOT EXISTS tbl_rider (
+  id BIGINT(20) NOT NULL AUTO_INCREMENT,
+  agency_id BIGINT(20) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE(id),
+  FOREIGN KEY (agency_id) REFERENCES tbl_agency (id)
+);
 -- -----------------------------------------------------
--- Table `tbl_delivery`
+-- Table tbl_delivery
 -- -----------------------------------------------------
-CREATE TABLE IF NOT EXISTS `tbl_delivery` (
-  `id` BIGINT(20) GENERATED ALWAYS AS (),
-  `order_id` BIGINT(20) NOT NULL,
-  `rider_id` BIGINT(20) NULL,
-  `agency_id` BIGINT(20) NULL,
-  `pickup_time` DATETIME NULL,
-  `finish_time` DATETIME NULL,
-  `created_at` DATETIME NULL,
-  `updated_at` DATETIME NULL,
-  PRIMARY KEY (`id`),
-  UNIQUE INDEX `id_UNIQUE` (`id` ASC) VISIBLE,
-  INDEX `fk_tbl_delivery_tbl_rider1_idx` (`rider_id` ASC) VISIBLE,
-  CONSTRAINT `fk_tbl_delivery_tbl_rider1`
-    FOREIGN KEY (`rider_id`)
-    REFERENCES `rider` (`id`)
-    ON DELETE NO ACTION
-    ON UPDATE NO ACTION)
-
-
+CREATE TABLE IF NOT EXISTS tbl_delivery (
+  id BIGINT(20) NOT NULL AUTO_INCREMENT,
+  order_id BIGINT(20) NOT NULL,
+  rider_id BIGINT(20) NULL,
+  agency_id BIGINT(20) NULL,
+  pickup_time DATETIME NULL,
+  finish_time DATETIME NULL,
+  created_at DATETIME NULL,
+  updated_at DATETIME NULL,
+  PRIMARY KEY (id),
+  UNIQUE (id),
+  FOREIGN KEY (rider_id) REFERENCES tbl_rider(id)
+);
 -- -----------------------------------------------------
--- Table `tbl_order`
+-- Table tbl_order
 -- -----------------------------------------------------
-CREATE TABLE IF NOT EXISTS `tbl_order` (
-  `id` BIGINT(20) GENERATED ALWAYS AS (),
-  `customer_id` BIGINT(20) NOT NULL,
-  `shop_id` BIGINT(20) NOT NULL,
-  `delivery_id` BIGINT(20) NULL,
-  `order_status` VARCHAR(50) NULL,
-  `address` VARCHAR(1000) NULL,
-  `phone_number` VARCHAR(200) NULL,
-  `created_at` DATETIME NULL,
-  `updated_at` DATETIME NULL,
-  PRIMARY KEY (`id`),
-  UNIQUE INDEX `id_UNIQUE` (`id` ASC) VISIBLE,
-  INDEX `fk_tbl_order_tbl_delivery1_idx` (`delivery_id` ASC) VISIBLE,
-  INDEX `fk_tbl_order_tbl_shop1_idx` (`shop_id` ASC) VISIBLE,
-  CONSTRAINT `fk_tbl_order_tbl_delivery1`
-    FOREIGN KEY (`delivery_id`)
-    REFERENCES `tbl_delivery` (`id`)
-    ON DELETE NO ACTION
-    ON UPDATE NO ACTION,
-  CONSTRAINT `fk_tbl_order_tbl_shop1`
-    FOREIGN KEY (`shop_id`)
-    REFERENCES `tbl_shop` (`id`)
-    ON DELETE NO ACTION
-    ON UPDATE NO ACTION)
-
-
--- -----------------------------------------------------
--- Table `tbl_menu`
--- -----------------------------------------------------
-CREATE TABLE IF NOT EXISTS `tbl_menu` (
-)
-
-
-
--- -----------------------------------------------------
--- Table `tbl_customer`
--- -----------------------------------------------------
-CREATE TABLE IF NOT EXISTS `tbl_customer` (
-
-)
+CREATE TABLE IF NOT EXISTS tbl_order (
+  id BIGINT(20) NOT NULL AUTO_INCREMENT,
+  customer_id BIGINT(20) NOT NULL,
+  shop_id BIGINT(20) NOT NULL,
+  delivery_id BIGINT(20) NULL,
+  order_status VARCHAR(50) NULL,
+  address VARCHAR(1000) NULL,
+  phone_number VARCHAR(200) NULL,
+  created_at DATETIME NULL,
+  updated_at DATETIME NULL,
+  PRIMARY KEY (id),
+  UNIQUE (id),
+  FOREIGN KEY (delivery_id) REFERENCES tbl_delivery (id),
+  FOREIGN KEY (shop_id) REFERENCES tbl_shop (id)
+);

--- a/order-server/src/main/resources/schema.sql
+++ b/order-server/src/main/resources/schema.sql
@@ -1,183 +1,102 @@
+CREATE SCHEMA IF NOT EXISTS `order_server` DEFAULT CHARACTER SET utf8 ;
+USE `order_server` ;
 
 -- -----------------------------------------------------
--- Schema inbobwetrust
+-- Table `tbl_agency`
 -- -----------------------------------------------------
-
--- -----------------------------------------------------
--- Schema inbobwetrust
--- -----------------------------------------------------
-CREATE SCHEMA IF NOT EXISTS `inbobwetrust` DEFAULT CHARACTER SET utf8 ;
-USE `inbobwetrust` ;
-
--- -----------------------------------------------------
--- Table `inbobwetrust`.`customer`
--- -----------------------------------------------------
-CREATE TABLE IF NOT EXISTS `inbobwetrust`.`customer` (
-  `id` BIGINT(20) UNSIGNED NOT NULL,
-  `name` VARCHAR(20) NOT NULL,
-  `password` VARCHAR(20) NOT NULL,
-  `tel` VARCHAR(13) NOT NULL,
-  `email` VARCHAR(45) NULL,
-  `address` VARCHAR(45) NULL COMMENT '\n',
-  `reg_date` DATETIME NOT NULL,
-  `mod_date` DATETIME NOT NULL,
-  PRIMARY KEY (`id`))
-
-
--- -----------------------------------------------------
--- Table `inbobwetrust`.`shop`
--- -----------------------------------------------------
-CREATE TABLE IF NOT EXISTS `inbobwetrust`.`shop` (
-  `id` BIGINT(20) NOT NULL,
-  `name` VARCHAR(45) NOT NULL,
-  `tel` VARCHAR(13) NOT NULL,
-  `address` VARCHAR(100) NOT NULL,
-  `status` VARCHAR(45) NOT NULL DEFAULT 'READY',
-  `owner_name` VARCHAR(20) NOT NULL,
-  `photo` BLOB NULL,
-  `reg_date` DATETIME NOT NULL,
-  `mod_date` DATETIME NOT NULL,
-  `work_start_time` DATETIME NULL,
-  `work_end_time` DATETIME NULL,
-  PRIMARY KEY (`id`))
-
-
-
--- -----------------------------------------------------
--- Table `inbobwetrust`.`menu`
--- -----------------------------------------------------
-CREATE TABLE IF NOT EXISTS `inbobwetrust`.`menu` (
-  `id` BIGINT(20) NOT NULL,
-  `shop_id` BIGINT(20) NOT NULL,
-  `name` VARCHAR(45) NOT NULL,
-  `price` INT NOT NULL,
-  `description` VARCHAR(200) NULL,
-  `photo` BLOB NULL,
+CREATE TABLE IF NOT EXISTS `tbl_agency` (
+  `id` BIGINT(20) GENERATED ALWAYS AS (),
+  `endpoint` VARCHAR(300) NOT NULL,
   PRIMARY KEY (`id`),
-  INDEX `fk_menu_shop_idx` (`shop_id` ASC) VISIBLE,
-  CONSTRAINT `fk_menu_shop`
-    FOREIGN KEY (`shop_id`)
-    REFERENCES `inbobwetrust`.`shop` (`id`)
-    ON DELETE NO ACTION
-    ON UPDATE NO ACTION)
-
+  UNIQUE INDEX `id_UNIQUE` (`id` ASC) VISIBLE)
 
 
 -- -----------------------------------------------------
--- Table `inbobwetrust`.`agency`
+-- Table `tbl_shop`
 -- -----------------------------------------------------
-CREATE TABLE IF NOT EXISTS `inbobwetrust`.`agency` (
-  `id` BIGINT(20) NOT NULL,
-  `name` VARCHAR(45) NOT NULL,
-  `status` VARCHAR(45) NOT NULL,
-  PRIMARY KEY (`id`))
-
-
+CREATE TABLE IF NOT EXISTS `tbl_shop` (
+  `id` BIGINT(20) GENERATED ALWAYS AS (),
+  `endpoint` VARCHAR(300) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE INDEX `id_UNIQUE` (`id` ASC) VISIBLE)
 
 -- -----------------------------------------------------
--- Table `inbobwetrust`.`rider`
+-- Table `tbl_rider`
 -- -----------------------------------------------------
-CREATE TABLE IF NOT EXISTS `inbobwetrust`.`rider` (
-  `id` VARCHAR(20) NOT NULL,
+CREATE TABLE IF NOT EXISTS `tbl_rider` (
+  `id` BIGINT(20) GENERATED ALWAYS AS (),
   `agency_id` BIGINT(20) NOT NULL,
-  `status` VARCHAR(45) NOT NULL,
-  `name` VARCHAR(20) NOT NULL,
-  `password` VARCHAR(45) NOT NULL,
-  `tel` VARCHAR(13) NOT NULL,
-  `email` VARCHAR(45) NULL,
-  `reg_date` DATETIME NOT NULL,
-  `mod_date` DATETIME NOT NULL,
+  INDEX `fk_table1_tbl_agency_idx` (`agency_id` ASC) VISIBLE,
   PRIMARY KEY (`id`),
-  INDEX `fk_rider_agency_idx` (`agency_id` ASC) VISIBLE,
-  CONSTRAINT `fk_rider_agency`
+  UNIQUE INDEX `id_UNIQUE` (`id` ASC) VISIBLE,
+  CONSTRAINT `fk_table1_tbl_agency`
     FOREIGN KEY (`agency_id`)
-    REFERENCES `inbobwetrust`.`agency` (`id`)
+    REFERENCES `tbl_agency` (`id`)
     ON DELETE NO ACTION
     ON UPDATE NO ACTION)
 
-
 -- -----------------------------------------------------
--- Table `inbobwetrust`.`order_table`
+-- Table `tbl_delivery`
 -- -----------------------------------------------------
-CREATE TABLE IF NOT EXISTS `inbobwetrust`.`order_table` (
-  `id` VARCHAR(20) NOT NULL,
-  `customer_id` VARCHAR(20) NOT NULL,
-  `shop_id` BIGINT(20) NOT NULL,
-  `rider_id` VARCHAR(20) NULL,
-  `status` VARCHAR(45) NOT NULL DEFAULT 'PAYMENT_READY',
-  `payment_type` VARCHAR(45) NOT NULL DEFAULT 'CASH',
-  `payment_price` BIGINT(20) NOT NULL,
-  `address` VARCHAR(45) NOT NULL,
-  `cumstomer_request` VARCHAR(45) NULL,
-  `reg_date` DATETIME NOT NULL,
-  `proc_date` DATETIME NOT NULL,
-  `order_status_last_updated` DATETIME NOT NULL,
+CREATE TABLE IF NOT EXISTS `tbl_delivery` (
+  `id` BIGINT(20) GENERATED ALWAYS AS (),
+  `order_id` BIGINT(20) NOT NULL,
+  `rider_id` BIGINT(20) NULL,
+  `agency_id` BIGINT(20) NULL,
+  `pickup_time` DATETIME NULL,
+  `finish_time` DATETIME NULL,
+  `created_at` DATETIME NULL,
+  `updated_at` DATETIME NULL,
   PRIMARY KEY (`id`),
-  INDEX `fk_order_table_user_idx` (`customer_id` ASC) VISIBLE,
-  INDEX `fk_order_table_rider_idx` (`rider_id` ASC) VISIBLE,
-  INDEX `fk_order_table_shop_idx` (`shop_id` ASC) VISIBLE,
-  CONSTRAINT `fk_order_table_user`
-    FOREIGN KEY (`customer_id`)
-    REFERENCES `inbobwetrust`.`customer` (`id`)
-    ON DELETE NO ACTION
-    ON UPDATE NO ACTION,
-  CONSTRAINT `fk_order_table_rider`
+  UNIQUE INDEX `id_UNIQUE` (`id` ASC) VISIBLE,
+  INDEX `fk_tbl_delivery_tbl_rider1_idx` (`rider_id` ASC) VISIBLE,
+  CONSTRAINT `fk_tbl_delivery_tbl_rider1`
     FOREIGN KEY (`rider_id`)
-    REFERENCES `inbobwetrust`.`rider` (`id`)
+    REFERENCES `rider` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION)
+
+
+-- -----------------------------------------------------
+-- Table `tbl_order`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `tbl_order` (
+  `id` BIGINT(20) GENERATED ALWAYS AS (),
+  `customer_id` BIGINT(20) NOT NULL,
+  `shop_id` BIGINT(20) NOT NULL,
+  `delivery_id` BIGINT(20) NULL,
+  `order_status` VARCHAR(50) NULL,
+  `address` VARCHAR(1000) NULL,
+  `phone_number` VARCHAR(200) NULL,
+  `created_at` DATETIME NULL,
+  `updated_at` DATETIME NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE INDEX `id_UNIQUE` (`id` ASC) VISIBLE,
+  INDEX `fk_tbl_order_tbl_delivery1_idx` (`delivery_id` ASC) VISIBLE,
+  INDEX `fk_tbl_order_tbl_shop1_idx` (`shop_id` ASC) VISIBLE,
+  CONSTRAINT `fk_tbl_order_tbl_delivery1`
+    FOREIGN KEY (`delivery_id`)
+    REFERENCES `tbl_delivery` (`id`)
     ON DELETE NO ACTION
     ON UPDATE NO ACTION,
-  CONSTRAINT `fk_order_table_shop`
+  CONSTRAINT `fk_tbl_order_tbl_shop1`
     FOREIGN KEY (`shop_id`)
-    REFERENCES `inbobwetrust`.`shop` (`id`)
+    REFERENCES `tbl_shop` (`id`)
     ON DELETE NO ACTION
     ON UPDATE NO ACTION)
 
 
-
 -- -----------------------------------------------------
--- Table `inbobwetrust`.`order_menu`
+-- Table `tbl_menu`
 -- -----------------------------------------------------
-CREATE TABLE IF NOT EXISTS `inbobwetrust`.`order_menu` (
-  `menu_id` BIGINT(20) NOT NULL,
-  `order_table_id` BIGINT(20) NOT NULL,
-  `quantity` INT NOT NULL,
-  PRIMARY KEY (`menu_id`, `order_table_id`),
-  INDEX `fk_order_menu_menu_idx` (`menu_id` ASC) VISIBLE,
-  INDEX `fk_order_menu_order_table_idx` (`order_table_id` ASC) VISIBLE,
-  CONSTRAINT `fk_order_menu_menu`
-    FOREIGN KEY (`menu_id`)
-    REFERENCES `inbobwetrust`.`menu` (`id`)
-    ON DELETE NO ACTION
-    ON UPDATE NO ACTION,
-  CONSTRAINT `fk_order_menu_order_table`
-    FOREIGN KEY (`order_table_id`)
-    REFERENCES `inbobwetrust`.`order_table` (`id`)
-    ON DELETE NO ACTION
-    ON UPDATE NO ACTION)
+CREATE TABLE IF NOT EXISTS `tbl_menu` (
+)
 
 
 
 -- -----------------------------------------------------
--- Table `inbobwetrust`.`delivery`
+-- Table `tbl_customer`
 -- -----------------------------------------------------
-CREATE TABLE IF NOT EXISTS `inbobwetrust`.`delivery` (
-  `order_table_id` BIGINT(20) NOT NULL,
-  `rider_id` VARCHAR(20) NOT NULL,
-  `wanted_pickup_time` DATETIME NOT NULL,
-  `estimated_cooking_time` DATETIME NOT NULL,
-  `estimated_delivery_finish_time` DATETIME NOT NULL,
-  `reg_date` DATETIME NOT NULL,
-  `mod_date` DATETIME NOT NULL,
-  INDEX `fk_delivery_order_table_idx` (`order_table_id` ASC) VISIBLE,
-  INDEX `fk_delivery_rider_idx` (`rider_id` ASC) VISIBLE,
-  PRIMARY KEY (`rider_id`, `order_table_id`),
-  CONSTRAINT `fk_delivery_order_table`
-    FOREIGN KEY (`order_table_id`)
-    REFERENCES `inbobwetrust`.`order_table` (`id`)
-    ON DELETE NO ACTION
-    ON UPDATE NO ACTION,
-  CONSTRAINT `fk_delivery_rider`
-    FOREIGN KEY (`rider_id`)
-    REFERENCES `inbobwetrust`.`rider` (`id`)
-    ON DELETE NO ACTION
-    ON UPDATE NO ACTION)
+CREATE TABLE IF NOT EXISTS `tbl_customer` (
+
+)


### PR DESCRIPTION
## Overview
- resolves #42
- DB Schema 간소화를 통한 중계서비스의 관심사 스코프 narrow-down(좁히다)

## Details

### New Schema

![Screen Shot 2021-12-16 at 12 00 03 AM](https://user-images.githubusercontent.com/61615301/146210440-221da882-3394-4a89-a904-772a37ed36b9.png)

- DBMS 정수 기본키(PK) `Auto-Increment` 기능을 레버리지하기 위해 모든 테이블 `BIGINT 자바 기준 Long` 으로 변경
- `주문 Order` 테이블을 `배달 Delivery` 를 통해 `라이더 Rider` 와 관계(Relation)을 맺으며 관심사 분리
- `배달 Delivery` 테이블을 스키마 관계들의 중심으로 이동
- 중계서비스의 관심사를 벗어난 `메뉴목록  ex) 김치찌개 2개 공기밥 추가`, `회원아이디`와 같은 컬럼 삭제


