### PR TITLE
 #87 신규주문접수 기능구현 데이터베이스저장

### DIFF
--- a/order-server/src/integrationTest/java/com/inbobwetrust/repository/MovieInfoRepositoryIntegrationTest.java
+++ b/order-server/src/integrationTest/java/com/inbobwetrust/repository/MovieInfoRepositoryIntegrationTest.java
@@ -1,0 +1,74 @@
+package com.inbobwetrust.repository;
+
+import com.inbobwetrust.domain.Delivery;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.test.context.ActiveProfiles;
+import reactor.test.StepVerifier;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataMongoTest // look for repository class, class available no need to  spin up whole context
+class MovieInfoRepositoryIntegrationTest {
+
+  @Autowired DeliveryRepository deliveryRepository;
+
+  @BeforeEach
+  void setUp() {}
+
+  @AfterEach
+  void tearDown() {
+    deliveryRepository.deleteAll().block();
+  }
+
+  private Delivery makeValidDelivery() {
+    return Delivery.builder()
+        .orderId("order-1234")
+        .customerId("customer-1234")
+        .address("서울시 강남구 삼성동 봉은사로 12-41")
+        .phoneNumber("01031583212")
+        .orderTime(LocalDateTime.now())
+        .build();
+  }
+
+  private Delivery makeInvalidDelivery() {
+    return Delivery.builder().build();
+  }
+
+  @Test
+  void save_success() {
+    // Arranged
+    var expected = makeValidDelivery();
+    // Act
+    var saved = deliveryRepository.save(expected);
+    // Assert
+    StepVerifier.create(saved)
+        .assertNext(
+            actual -> {
+              Assertions.assertNotNull(actual.getId());
+              Assertions.assertEquals(expected.getCustomerId(), actual.getCustomerId());
+              Assertions.assertEquals(expected.getAddress(), actual.getAddress());
+              Assertions.assertEquals(expected.getPhoneNumber(), actual.getPhoneNumber());
+              Assertions.assertEquals(expected.getOrderTime(), actual.getOrderTime());
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void save_fail_nullParam() {
+    // Arrange
+    Delivery expected = null;
+    // Act
+    // Assert
+    Assertions.assertThrows(
+        IllegalArgumentException.class, () -> deliveryRepository.save(expected));
+  }
+}

--- a/order-server/src/main/java/com/inbobwetrust/domain/Delivery.java
+++ b/order-server/src/main/java/com/inbobwetrust/domain/Delivery.java
@@ -16,6 +16,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 public class Delivery {
   @Id private String id;
 
+  @NotNull(message = "주문번호는 필수 입력값입니다.")
   private String orderId;
 
   private String riderId;

--- a/order-server/src/main/java/com/inbobwetrust/publisher/DeliveryPublisher.java
+++ b/order-server/src/main/java/com/inbobwetrust/publisher/DeliveryPublisher.java
@@ -4,5 +4,5 @@ import com.inbobwetrust.domain.Delivery;
 
 public interface DeliveryPublisher {
 
-  void sendAddDeliveryEvent(Delivery delivery);
+  Delivery sendAddDeliveryEvent(Delivery delivery);
 }

--- a/order-server/src/main/java/com/inbobwetrust/publisher/DeliveryPublisher.java
+++ b/order-server/src/main/java/com/inbobwetrust/publisher/DeliveryPublisher.java
@@ -1,0 +1,9 @@
+package com.inbobwetrust.publisher;
+
+import com.inbobwetrust.domain.Delivery;
+import reactor.core.publisher.Mono;
+
+public interface DeliveryPublisher {
+
+  void sendAddDeliveryEvent(Delivery delivery);
+}

--- a/order-server/src/main/java/com/inbobwetrust/repository/DeliveryRepository.java
+++ b/order-server/src/main/java/com/inbobwetrust/repository/DeliveryRepository.java
@@ -1,0 +1,6 @@
+package com.inbobwetrust.repository;
+
+import com.inbobwetrust.domain.Delivery;
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+
+public interface DeliveryRepository extends ReactiveMongoRepository<Delivery, String> {}

--- a/order-server/src/main/java/com/inbobwetrust/service/DeliveryServiceImpl.java
+++ b/order-server/src/main/java/com/inbobwetrust/service/DeliveryServiceImpl.java
@@ -1,0 +1,26 @@
+package com.inbobwetrust.service;
+
+import com.inbobwetrust.domain.Delivery;
+import com.inbobwetrust.publisher.DeliveryPublisher;
+import com.inbobwetrust.repository.DeliveryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DeliveryServiceImpl implements DeliveryService {
+
+  private final DeliveryRepository deliveryRepository;
+  private final DeliveryPublisher deliveryPublisher;
+
+  @Override
+  public Mono<Delivery> addDelivery(Delivery delivery) {
+    return deliveryRepository
+        .save(delivery)
+        .onErrorReturn(IllegalArgumentException.class, null)
+        .doOnNext(deliveryPublisher::sendAddDeliveryEvent);
+  }
+}

--- a/order-server/src/main/java/com/inbobwetrust/service/DeliveryServiceImpl.java
+++ b/order-server/src/main/java/com/inbobwetrust/service/DeliveryServiceImpl.java
@@ -18,9 +18,6 @@ public class DeliveryServiceImpl implements DeliveryService {
 
   @Override
   public Mono<Delivery> addDelivery(Delivery delivery) {
-    return deliveryRepository
-        .save(delivery)
-        .onErrorReturn(IllegalArgumentException.class, null)
-        .doOnNext(deliveryPublisher::sendAddDeliveryEvent);
+    return deliveryRepository.save(delivery).doOnNext(deliveryPublisher::sendAddDeliveryEvent);
   }
 }

--- a/order-server/src/test/java/com/inbobwetrust/controller/DeliveryControllerTest.java
+++ b/order-server/src/test/java/com/inbobwetrust/controller/DeliveryControllerTest.java
@@ -26,6 +26,7 @@ public class DeliveryControllerTest {
 
   private Delivery makeValidDelivery() {
     return Delivery.builder()
+        .orderId("order-1234")
         .customerId("customer-1234")
         .address("서울시 강남구 삼성동 봉은사로 12-41")
         .phoneNumber("01031583212")

--- a/order-server/src/test/java/com/inbobwetrust/service/DeliveryServiceImplTest.java
+++ b/order-server/src/test/java/com/inbobwetrust/service/DeliveryServiceImplTest.java
@@ -1,0 +1,66 @@
+package com.inbobwetrust.service;
+
+import com.inbobwetrust.domain.Delivery;
+import com.inbobwetrust.publisher.DeliveryPublisher;
+import com.inbobwetrust.repository.DeliveryRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class DeliveryServiceImplTest {
+  @InjectMocks DeliveryServiceImpl deliveryService;
+  @Mock DeliveryRepository deliveryRepository;
+  @Mock DeliveryPublisher deliveryPublisher;
+
+  private Delivery makeValidDelivery() {
+    return Delivery.builder()
+        .orderId("order-1234")
+        .customerId("customer-1234")
+        .address("서울시 강남구 삼성동 봉은사로 12-41")
+        .phoneNumber("01031583212")
+        .orderTime(LocalDateTime.now())
+        .build();
+  }
+
+  private Delivery makeInvalidDelivery() {
+    return Delivery.builder().build();
+  }
+
+  @Test
+  void addDelivery_success() {
+    // Arrange
+    Delivery expected = makeValidDelivery();
+    // Stub
+    when(deliveryRepository.save(isA(Delivery.class))).thenReturn(Mono.just(expected));
+    doNothing().when(deliveryPublisher).sendAddDeliveryEvent(isA(Delivery.class));
+    // Act
+    var result = deliveryService.addDelivery(expected);
+    // Assert
+    StepVerifier.create(result).expectNext(expected);
+    verify(deliveryRepository, times(1)).save(any(Delivery.class));
+  }
+
+  @Test
+  void addDelivery_fail_null() {
+    // Arrange
+    // Stub
+    when(deliveryRepository.save(any())).thenReturn(Mono.error(IllegalArgumentException::new));
+    // Act
+    var result = deliveryService.addDelivery(null);
+    // Assert
+    StepVerifier.create(result).expectError(IllegalArgumentException.class);
+    verify(deliveryRepository, times(1)).save(any());
+  }
+}

--- a/order-server/src/test/java/com/inbobwetrust/service/DeliveryServiceImplTest.java
+++ b/order-server/src/test/java/com/inbobwetrust/service/DeliveryServiceImplTest.java
@@ -44,7 +44,6 @@ public class DeliveryServiceImplTest {
     Delivery expected = makeValidDelivery();
     // Stub
     when(deliveryRepository.save(isA(Delivery.class))).thenReturn(Mono.just(expected));
-    doNothing().when(deliveryPublisher).sendAddDeliveryEvent(isA(Delivery.class));
     // Act
     var result = deliveryService.addDelivery(expected);
     // Assert


### PR DESCRIPTION
## Description
- Issue #87 의 **Sub-Issue**입니다.
- PR #89 의 "next"입니다.

## Changes
- `Delivery` 도메인 `주문번호(orderId)`에 validation 추가
- **신규주문접수 -> DB 저장**에 대해 **사장님 주문접수요청 전송**하는 `interface DeliveryPublisher`추가
- `ReactiveMongoRepository`를 상속하는 `DeliveryRepository` 추가
- `DeliveryService` 구현체 작성