### PR TITLE
#000 메인 브랜치 구글포매팅 설정해제

### DIFF
--- a/.github/workflows/google-java-format.yml
+++ b/.github/workflows/google-java-format.yml
@@ -1,8 +1,10 @@
 # Example workflow
 name: Format
 
-on: [ push ]
-
+on:
+  push:
+    branches-ignore:
+      - 'main'
 jobs:
 
   formatting:


### PR DESCRIPTION
- main 브랜치에 google-java-formatter가 적용되는것을 해제합니다.
- remote 푸시 이벤트에 이미 적용해뒀기 때문에 중복이 발생하며 main 브랜치의 commit 메시지 컨벤션을 오염시키기 때문입니다.