### PR TITLE
#hotfix 도커 이미지 빌드 워크플로우 MacOS runner 미지원

### DIFF
--- a/.github/workflows/delivery-info-service.yml
+++ b/.github/workflows/delivery-info-service.yml
@@ -83,7 +83,7 @@ jobs:
       fail-fast: true
       matrix:
         IMAGE_BUILD_DIR_PAIR: [ [ 'delivery-info-service', './delivery-info-service' ] ]
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     env:
       MODULE_NAME: delivery-info-service
 

--- a/.github/workflows/delivery-info-service.yml
+++ b/.github/workflows/delivery-info-service.yml
@@ -29,7 +29,7 @@ jobs:
         run: ./gradlew ${{ matrix.TEST_COMMAND }}
 
   load_test:
-    runs-on: self-hosted
+    runs-on: [loadtest, self-hosted]
     strategy:
       fail-fast: true
     steps:


### PR DESCRIPTION
## Description
- 과거 시간 소모가 큰 workflow job은 모두 ubuntu 에서 실행하게 했습니다.
- 하지만 docker/actions 공식 액션은 MacOS 를 지원하지 않습니다.
- 그래서 빌드 job 은 github 의 runner을 사용하고자 합니다.