### PR TITLE
#149 [delivery-relay-service] 테스트 커버리지 상승 

### DIFF
--- a/.github/workflows/delivery-info-service.yml
+++ b/.github/workflows/delivery-info-service.yml
@@ -31,8 +31,6 @@ jobs:
 
   load_test:
     runs-on: [ loadtest, self-hosted ]
-    strategy:
-      fail-fast: true
     steps:
       - uses: actions/checkout@v2
 
@@ -72,8 +70,7 @@ jobs:
         run: curl  --max-time 10  http://localhost:8888/api/delivery
 
       - name: K6 > Test Local
-        run: |
-        K6_PROMETHEUS_REMOTE_URL=http://localhost:9090/api/v1/write ./k6-test/k6 run  ./k6-test/simple-delivery-get.js  -o output-prometheus-remote &&  k6 run ./k6-test/process_cpu_usage.js
+        run: K6_PROMETHEUS_REMOTE_URL=http://localhost:9090/api/v1/write ./k6-test/k6 run  ./k6-test/simple-delivery-get.js -o output-prometheus-remote &&  k6 run ./k6-test/process_cpu_usage.js
 
   build-image:
     needs:

--- a/.github/workflows/delivery-info-service.yml
+++ b/.github/workflows/delivery-info-service.yml
@@ -30,7 +30,7 @@ jobs:
         run: ./gradlew ${{ matrix.TEST_COMMAND }}
 
   load_test:
-    runs-on: [loadtest, self-hosted]
+    runs-on: [ loadtest, self-hosted ]
     strategy:
       fail-fast: true
     steps:
@@ -73,7 +73,7 @@ jobs:
 
       - name: K6 > Test Local
         run: |
-          k6 run ./k6-test/simple-delivery-get.js &&  k6 run ./k6-test/process_cpu_usage.js
+        K6_PROMETHEUS_REMOTE_URL=http://localhost:9090/api/v1/write ./k6-test/k6 run  ./k6-test/simple-delivery-get.js  -o output-prometheus-remote &&  k6 run ./k6-test/process_cpu_usage.js
 
   build-image:
     needs:

--- a/delivery-relay-service/build.gradle
+++ b/delivery-relay-service/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 group = 'com.woojoolion'
 sourceCompatibility = 11
-def jacocoMinimumCoverageRatio = 0.50
+def jacocoMinimumCoverageRatio = 1.0
 def jarFileName = 'delivery-relay-service'
 
 bootJar {
@@ -59,6 +59,7 @@ jacocoTestReport {
     dependsOn test
     sourceSets sourceSets.main
     executionData fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec")
+    mustRunAfter('integrationTest')
 }
 
 jacoco {
@@ -102,7 +103,6 @@ idea {
         testSourceDirs += project.sourceSets.integrationTest.resources.srcDirs
     }
 }
-
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'

--- a/delivery-relay-service/lombok.config
+++ b/delivery-relay-service/lombok.config
@@ -1,0 +1,2 @@
+lombok.addLombokGeneratedAnnotation = true
+

--- a/delivery-relay-service/src/test/java/com/inbobwetrust/DeliveryRelayServiceApplicationTest.java
+++ b/delivery-relay-service/src/test/java/com/inbobwetrust/DeliveryRelayServiceApplicationTest.java
@@ -1,16 +1,50 @@
 package com.inbobwetrust;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.util.SocketUtils;
 
 public class DeliveryRelayServiceApplicationTest {
-  @Test
-  void name() {
-    // Arrange
-    // Stub
-    // Act
+  int serverPort;
 
-    // Assert
-    Assertions.assertEquals(1, 1);
+  @BeforeEach
+  void setUp() {
+    System.getProperties().put("server.port", SocketUtils.findAvailableTcpPort());
+  }
+
+  @Test
+  void defaultProfileTest() {
+    Assertions.assertThrows(
+        BeanCreationException.class,
+        () -> {
+          DeliveryRelayServiceApplication.main(new String[] {});
+        });
+  }
+
+  @Test
+  void productionProfileTest() {
+    Assertions.assertDoesNotThrow(
+        () -> {
+          DeliveryRelayServiceApplication.main(
+              new String[] {"--spring.profiles.active=production"});
+        });
+  }
+
+  @Test
+  void localProfileTest() {
+    Assertions.assertDoesNotThrow(
+        () -> {
+          DeliveryRelayServiceApplication.main(new String[] {"--spring.profiles.active=local"});
+        });
+  }
+
+  @Test
+  void testProfileTest() {
+    Assertions.assertDoesNotThrow(
+        () -> {
+          DeliveryRelayServiceApplication.main(new String[] {"--spring.profiles.active=test"});
+        });
   }
 }


### PR DESCRIPTION
## Description
- part of Issue #149 
- `delivery-relay-service`의 테스트 커버리지를 100%로 증가시켰습니다.
- 롬복의 generated 는 Jacoco 에서 제외됩니다.