### PR TITLE
#158 [Fix] 워크플로우파일 single quote

### DIFF
--- a/.github/workflows/delivery-info-service.yml
+++ b/.github/workflows/delivery-info-service.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Docker > Build image
         run: |
           docker image build \
-          --build-arg VERSION='-Ddocker.image.version=${GITHUB_SHA::7}' \
+          --build-arg VERSION=-Ddocker.image.version=${GITHUB_SHA::7} \
           -t ${{ secrets.DOCKERHUB_USERNAME }}/${{matrix.IMAGE_BUILD_DIR_PAIR[0]}}:latest \
           -t ${{ secrets.DOCKERHUB_USERNAME }}/${{matrix.IMAGE_BUILD_DIR_PAIR[0]}}:${GITHUB_SHA::7} \
           ${{matrix.IMAGE_BUILD_DIR_PAIR[1]}}


### PR DESCRIPTION
## Description
- part of #158 
- build_image 의 `run` 커맨드의  single quote 은 GITHUB_SHA 해시가 적용이 안되는 에러