### PR TITLE
#198 비동기 통신을 위한 RabbitMQ 환경설정

### DIFF
--- a/delivery-info-service/build.gradle
+++ b/delivery-info-service/build.gradle
@@ -135,6 +135,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-webflux-ui:1.6.3'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
     if (System.getProperty("os.arch").equals("aarch64")) { // 맥 M1 DNS리졸버 버그해결
         implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
     }
@@ -146,6 +147,7 @@ dependencies {
     testImplementation "org.testcontainers:testcontainers:1.16.2"
     testImplementation "org.testcontainers:junit-jupiter:1.16.2"
     testImplementation 'de.flapdoodle.embed:de.flapdoodle.embed.mongo'
+    testImplementation "org.testcontainers:rabbitmq:1.16.3"
 }
 
 

--- a/delivery-info-service/build.gradle
+++ b/delivery-info-service/build.gradle
@@ -135,6 +135,8 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-webflux-ui:1.6.3'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation "org.springframework.cloud:spring-cloud-starter-sleuth"
+    implementation "org.springframework.cloud:spring-cloud-sleuth-zipkin"
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
     if (System.getProperty("os.arch").equals("aarch64")) { // 맥 M1 DNS리졸버 버그해결
         implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'

--- a/delivery-info-service/build.gradle
+++ b/delivery-info-service/build.gradle
@@ -135,8 +135,6 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-webflux-ui:1.6.3'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
-    implementation "org.springframework.cloud:spring-cloud-starter-sleuth"
-    implementation "org.springframework.cloud:spring-cloud-sleuth-zipkin"
     if (System.getProperty("os.arch").equals("aarch64")) { // 맥 M1 DNS리졸버 버그해결
         implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
     }

--- a/delivery-info-service/src/main/resources/application.yml
+++ b/delivery-info-service/src/main/resources/application.yml
@@ -7,6 +7,9 @@ spring:
   mongodb:
     embedded:
       version: 3.5.5
+  rabbitmq:
+    host: 127.0.0.1
+    port: 5672
 
 hello:
   sha: aaaaaa

--- a/delivery-info-service/src/main/resources/application.yml
+++ b/delivery-info-service/src/main/resources/application.yml
@@ -7,6 +7,7 @@ spring:
   mongodb:
     embedded:
       version: 3.5.5
-  rabbitmq:
-    host: 127.0.0.1
-    port: 5672
+
+hello:
+  sha: aaaaaa
+  world: Hello World! from Delivery-Info-Service ${hello.sha}.from Here

--- a/delivery-info-service/src/main/resources/application.yml
+++ b/delivery-info-service/src/main/resources/application.yml
@@ -7,7 +7,6 @@ spring:
   mongodb:
     embedded:
       version: 3.5.5
-
-hello:
-  sha: aaaaaa
-  world: Hello World! from Delivery-Info-Service ${hello.sha}.from Here
+  rabbitmq:
+    host: 127.0.0.1
+    port: 5672

--- a/delivery-relay-service/build.gradle
+++ b/delivery-relay-service/build.gradle
@@ -133,6 +133,8 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-webflux-ui:1.6.3'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation "org.springframework.cloud:spring-cloud-starter-sleuth"
+    implementation "org.springframework.cloud:spring-cloud-sleuth-zipkin"
     implementation 'org.springdoc:springdoc-openapi-webflux-ui:1.6.3'
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
     if (System.getProperty("os.arch").equals("aarch64")) { // 맥 M1 DNS리졸버 버그해결

--- a/delivery-relay-service/build.gradle
+++ b/delivery-relay-service/build.gradle
@@ -134,6 +134,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springdoc:springdoc-openapi-webflux-ui:1.6.3'
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
     if (System.getProperty("os.arch").equals("aarch64")) { // 맥 M1 DNS리졸버 버그해결
         implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
     }
@@ -143,4 +144,5 @@ dependencies {
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'org.springframework.cloud:spring-cloud-starter-contract-stub-runner:3.0.3'
     testImplementation 'de.flapdoodle.embed:de.flapdoodle.embed.mongo'
+    testImplementation "org.testcontainers:rabbitmq:1.16.3"
 }

--- a/delivery-relay-service/build.gradle
+++ b/delivery-relay-service/build.gradle
@@ -133,10 +133,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-webflux-ui:1.6.3'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
-    implementation "org.springframework.cloud:spring-cloud-starter-sleuth"
-    implementation "org.springframework.cloud:spring-cloud-sleuth-zipkin"
     implementation 'org.springdoc:springdoc-openapi-webflux-ui:1.6.3'
-
     if (System.getProperty("os.arch").equals("aarch64")) { // 맥 M1 DNS리졸버 버그해결
         implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
     }

--- a/delivery-relay-service/src/main/resources/application.yml
+++ b/delivery-relay-service/src/main/resources/application.yml
@@ -11,6 +11,9 @@ spring:
   mongodb:
     embedded:
       version: 3.5.5
+  rabbitmq:
+    host: 127.0.0.1
+    port: 5672
 
 management:
   endpoints:

--- a/delivery-relay-service/src/main/resources/application.yml
+++ b/delivery-relay-service/src/main/resources/application.yml
@@ -1,15 +1,16 @@
 server:
   port: 8090
 
+hello:
+  sha: aaaaaa
+  world: Hello World! from Delivery-Relay-Service ${hello.sha}.from Here
+
 spring:
   profiles:
     active: production
   mongodb:
     embedded:
       version: 3.5.5
-  rabbitmq:
-    host: 127.0.0.1
-    port: 5672
 
 management:
   endpoints:

--- a/delivery-relay-service/src/main/resources/application.yml
+++ b/delivery-relay-service/src/main/resources/application.yml
@@ -1,16 +1,15 @@
 server:
   port: 8090
 
-hello:
-  sha: aaaaaa
-  world: Hello World! from Delivery-Relay-Service ${hello.sha}.from Here
-
 spring:
   profiles:
     active: production
   mongodb:
     embedded:
       version: 3.5.5
+  rabbitmq:
+    host: 127.0.0.1
+    port: 5672
 
 management:
   endpoints:


### PR DESCRIPTION
## Overview
- part of issue #198 
- `delivery-info-service` 와 `delivery-relay-service` 사이에 메시지 큐(RabbitMQ)를 두고 통신하기 위한 환경설정

## Changes
- `spring-boot-starter-amqp` == `RabbitMQ` 클라이언트 설정
- 미사용 어플리케이션 프로퍼티인 `${hello.sha.world}` 삭제
