### PR TITLE
#198 신규주문에 대한 메시지 Publish 기능 어플리케이션에 추가

### DIFF
--- a/delivery-info-service/src/integrationTest/java/com/inbobwetrust/publisher/DeliveryMessagePublisherImplTest.java
+++ b/delivery-info-service/src/integrationTest/java/com/inbobwetrust/publisher/DeliveryMessagePublisherImplTest.java
@@ -21,8 +21,8 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.LocalDateTime;
 
-import static org.codehaus.groovy.runtime.DefaultGroovyMethods.any;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)

--- a/delivery-info-service/src/integrationTest/java/com/inbobwetrust/publisher/DeliveryMessagePublisherImplTest.java
+++ b/delivery-info-service/src/integrationTest/java/com/inbobwetrust/publisher/DeliveryMessagePublisherImplTest.java
@@ -1,7 +1,12 @@
 package com.inbobwetrust.publisher;
 
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+
 import com.inbobwetrust.domain.Delivery;
 import com.inbobwetrust.repository.DeliveryRepository;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
@@ -19,12 +24,6 @@ import org.testcontainers.containers.RabbitMQContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import java.time.LocalDateTime;
-
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureWebTestClient
 @Testcontainers
@@ -37,17 +36,14 @@ public class DeliveryMessagePublisherImplTest {
   @Value("messageQueue.exchange.agency")
   private String agencyExchange;
 
-  @Autowired
-  WebTestClient webTestClient;
+  @Autowired WebTestClient webTestClient;
 
-  @Autowired
-  DeliveryRepository deliveryRepository;
+  @Autowired DeliveryRepository deliveryRepository;
 
   @Container
   static RabbitMQContainer container = new RabbitMQContainer("rabbitmq:3.7.25-management-alpine");
 
-  @SpyBean
-  AmqpTemplate amqpTemplate;
+  @SpyBean AmqpTemplate amqpTemplate;
 
   @DynamicPropertySource
   static void configure(DynamicPropertyRegistry registry) {
@@ -60,16 +56,17 @@ public class DeliveryMessagePublisherImplTest {
     // given
     var delivery = makeValidDelivery();
     // when
-    var resBody = this.webTestClient
-        .post()
-        .uri("/api/delivery")
-        .bodyValue(delivery)
-        .exchange()
-        .expectStatus()
-        .isOk()
-        .expectBody(Delivery.class)
-        .returnResult()
-        .getResponseBody();
+    var resBody =
+        this.webTestClient
+            .post()
+            .uri("/api/delivery")
+            .bodyValue(delivery)
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody(Delivery.class)
+            .returnResult()
+            .getResponseBody();
 
     Thread.sleep(1000L);
     // then
@@ -77,7 +74,8 @@ public class DeliveryMessagePublisherImplTest {
     delivery.setId(savedDelivery.getId());
     assertTrue(delivery.getShopId().equals(savedDelivery.getShopId()));
     assertTrue(delivery.getCustomerId().equals(savedDelivery.getCustomerId()));
-    Mockito.verify(amqpTemplate, times(1)).convertAndSend(ArgumentMatchers.eq(shopExchange), any(Delivery.class));
+    Mockito.verify(amqpTemplate, times(1))
+        .convertAndSend(ArgumentMatchers.eq(shopExchange), any(Delivery.class));
   }
 
   private Delivery makeValidDelivery() {

--- a/delivery-info-service/src/integrationTest/java/com/inbobwetrust/publisher/DeliveryMessagePublisherImplTest.java
+++ b/delivery-info-service/src/integrationTest/java/com/inbobwetrust/publisher/DeliveryMessagePublisherImplTest.java
@@ -1,13 +1,7 @@
 package com.inbobwetrust.publisher;
 
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
 import com.inbobwetrust.domain.Delivery;
 import com.inbobwetrust.repository.DeliveryRepository;
-import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 import org.springframework.amqp.core.AmqpTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,11 +9,13 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.testcontainers.containers.RabbitMQContainer;
 import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.LocalDateTime;
 
@@ -31,8 +27,8 @@ import static org.mockito.Mockito.verify;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureWebTestClient
-// @Testcontainers
-// @ContextConfiguration
+@Testcontainers
+@ContextConfiguration
 public class DeliveryMessagePublisherImplTest {
 
   @Value("messageQueue.exchange.shop")
@@ -65,15 +61,15 @@ public class DeliveryMessagePublisherImplTest {
     var delivery = makeValidDelivery();
     // when
     var resBody = this.webTestClient
-        .post()
-        .uri("/api/delivery")
-        .bodyValue(delivery)
-        .exchange()
-        .expectStatus()
-        .isOk()
-        .expectBody(Delivery.class)
-        .returnResult()
-        .getResponseBody();
+      .post()
+      .uri("/api/delivery")
+      .bodyValue(delivery)
+      .exchange()
+      .expectStatus()
+      .isOk()
+      .expectBody(Delivery.class)
+      .returnResult()
+      .getResponseBody();
 
     Thread.sleep(1000L);
     // then
@@ -86,12 +82,12 @@ public class DeliveryMessagePublisherImplTest {
 
   private Delivery makeValidDelivery() {
     return Delivery.builder()
-        .shopId("shop1234")
-        .orderId("order-1234")
-        .customerId("customer-1234")
-        .address("서울시 강남구 삼성동 봉은사로 12-41")
-        .phoneNumber("01031583212")
-        .orderTime(LocalDateTime.now())
-        .build();
+      .shopId("shop1234")
+      .orderId("order-1234")
+      .customerId("customer-1234")
+      .address("서울시 강남구 삼성동 봉은사로 12-41")
+      .phoneNumber("01031583212")
+      .orderTime(LocalDateTime.now())
+      .build();
   }
 }

--- a/delivery-info-service/src/integrationTest/java/com/inbobwetrust/publisher/DeliveryMessagePublisherImplTest.java
+++ b/delivery-info-service/src/integrationTest/java/com/inbobwetrust/publisher/DeliveryMessagePublisherImplTest.java
@@ -3,6 +3,8 @@ package com.inbobwetrust.publisher;
 import com.inbobwetrust.domain.Delivery;
 import com.inbobwetrust.repository.DeliveryRepository;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
 import org.springframework.amqp.core.AmqpTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,6 +18,12 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import org.testcontainers.containers.RabbitMQContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.LocalDateTime;
+
+import static org.codehaus.groovy.runtime.DefaultGroovyMethods.any;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.times;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureWebTestClient
@@ -53,15 +61,15 @@ public class DeliveryMessagePublisherImplTest {
     var delivery = makeValidDelivery();
     // when
     var resBody = this.webTestClient
-        .post()
-        .uri("/api/delivery")
-        .bodyValue(delivery)
-        .exchange()
-        .expectStatus()
-        .isOk()
-        .expectBody(Delivery.class)
-        .returnResult()
-        .getResponseBody();
+      .post()
+      .uri("/api/delivery")
+      .bodyValue(delivery)
+      .exchange()
+      .expectStatus()
+      .isOk()
+      .expectBody(Delivery.class)
+      .returnResult()
+      .getResponseBody();
 
     Thread.sleep(1000L);
     // then
@@ -69,17 +77,17 @@ public class DeliveryMessagePublisherImplTest {
     delivery.setId(savedDelivery.getId());
     assertTrue(delivery.getShopId().equals(savedDelivery.getShopId()));
     assertTrue(delivery.getCustomerId().equals(savedDelivery.getCustomerId()));
-    verify(amqpTemplate, times(1)).convertAndSend(eq(shopExchange), any(Delivery.class));
+    Mockito.verify(amqpTemplate, times(1)).convertAndSend(ArgumentMatchers.eq(shopExchange), any(Delivery.class));
   }
 
   private Delivery makeValidDelivery() {
     return Delivery.builder()
-        .shopId("shop1234")
-        .orderId("order-1234")
-        .customerId("customer-1234")
-        .address("서울시 강남구 삼성동 봉은사로 12-41")
-        .phoneNumber("01031583212")
-        .orderTime(LocalDateTime.now())
-        .build();
+      .shopId("shop1234")
+      .orderId("order-1234")
+      .customerId("customer-1234")
+      .address("서울시 강남구 삼성동 봉은사로 12-41")
+      .phoneNumber("01031583212")
+      .orderTime(LocalDateTime.now())
+      .build();
   }
 }

--- a/delivery-info-service/src/integrationTest/java/com/inbobwetrust/publisher/DeliveryMessagePublisherImplTest.java
+++ b/delivery-info-service/src/integrationTest/java/com/inbobwetrust/publisher/DeliveryMessagePublisherImplTest.java
@@ -12,11 +12,14 @@ import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.junit.jupiter.Container;
 
 import java.time.LocalDateTime;
 
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -38,22 +41,16 @@ public class DeliveryMessagePublisherImplTest {
   @Autowired
   DeliveryRepository deliveryRepository;
 
-//  @Container
-//  static RabbitMQContainer container = new RabbitMQContainer("rabbitmq:3.7.25-management-alpine");
+  @Container
+  static RabbitMQContainer container = new RabbitMQContainer("rabbitmq:3.7.25-management-alpine");
 
   @SpyBean
   AmqpTemplate amqpTemplate;
-//
-//  @DynamicPropertySource
-//  static void configure(DynamicPropertyRegistry registry) {
-//    registry.add("spring.rabbitmq.host", container::getContainerIpAddress);
-//    registry.add("spring.rabbitmq.port", container::getAmqpPort);
-//  }
 
   @DynamicPropertySource
   static void configure(DynamicPropertyRegistry registry) {
-    registry.add("spring.rabbitmq.host", () -> "127.0.0.1");
-    registry.add("spring.rabbitmq.port", () -> "5672");
+    registry.add("spring.rabbitmq.host", container::getContainerIpAddress);
+    registry.add("spring.rabbitmq.port", container::getAmqpPort);
   }
 
   @Test

--- a/delivery-info-service/src/integrationTest/java/com/inbobwetrust/publisher/DeliveryMessagePublisherImplTest.java
+++ b/delivery-info-service/src/integrationTest/java/com/inbobwetrust/publisher/DeliveryMessagePublisherImplTest.java
@@ -1,0 +1,93 @@
+package com.inbobwetrust.publisher;
+
+import com.inbobwetrust.domain.Delivery;
+import com.inbobwetrust.repository.DeliveryRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.core.AmqpTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import java.time.LocalDateTime;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+//@Testcontainers
+//@ContextConfiguration
+public class DeliveryMessagePublisherImplTest {
+
+  @Value("messageQueue.exchange.shop")
+  private String shopExchange;
+
+  @Value("messageQueue.exchange.agency")
+  private String agencyExchange;
+
+  @Autowired
+  WebTestClient webTestClient;
+
+  @Autowired
+  DeliveryRepository deliveryRepository;
+
+//  @Container
+//  static RabbitMQContainer container = new RabbitMQContainer("rabbitmq:3.7.25-management-alpine");
+
+  @SpyBean
+  AmqpTemplate amqpTemplate;
+//
+//  @DynamicPropertySource
+//  static void configure(DynamicPropertyRegistry registry) {
+//    registry.add("spring.rabbitmq.host", container::getContainerIpAddress);
+//    registry.add("spring.rabbitmq.port", container::getAmqpPort);
+//  }
+
+  @DynamicPropertySource
+  static void configure(DynamicPropertyRegistry registry) {
+    registry.add("spring.rabbitmq.host", () -> "127.0.0.1");
+    registry.add("spring.rabbitmq.port", () -> "5672");
+  }
+
+  @Test
+  void sendAddDeliveryEventTest() throws InterruptedException {
+    // given
+    var delivery = makeValidDelivery();
+    // when
+    var resBody = this.webTestClient.post()
+      .uri("/api/delivery")
+      .bodyValue(delivery)
+      .exchange()
+      .expectStatus()
+      .isOk()
+      .expectBody(Delivery.class)
+      .returnResult()
+      .getResponseBody();
+
+    Thread.sleep(1000L);
+    // then
+    var savedDelivery = deliveryRepository.findAll().blockLast();
+    delivery.setId(savedDelivery.getId());
+    assertTrue(delivery.getShopId().equals(savedDelivery.getShopId()));
+    assertTrue(delivery.getCustomerId().equals(savedDelivery.getCustomerId()));
+    verify(amqpTemplate, times(1)).convertAndSend(eq(shopExchange), any(Delivery.class));
+  }
+
+  private Delivery makeValidDelivery() {
+    return Delivery.builder()
+      .shopId("shop1234")
+      .orderId("order-1234")
+      .customerId("customer-1234")
+      .address("서울시 강남구 삼성동 봉은사로 12-41")
+      .phoneNumber("01031583212")
+      .orderTime(LocalDateTime.now())
+      .build();
+  }
+}

--- a/delivery-info-service/src/main/java/com/inbobwetrust/config/Jack2JsonConfiguration.java
+++ b/delivery-info-service/src/main/java/com/inbobwetrust/config/Jack2JsonConfiguration.java
@@ -1,0 +1,17 @@
+package com.inbobwetrust.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class Jack2JsonConfiguration {
+
+  @Bean
+  public Jackson2JsonMessageConverter jsonMessageConverter() {
+    return new Jackson2JsonMessageConverter(
+      new ObjectMapper().registerModule(new JavaTimeModule()));
+  }
+}

--- a/delivery-info-service/src/main/java/com/inbobwetrust/config/Jack2JsonConfiguration.java
+++ b/delivery-info-service/src/main/java/com/inbobwetrust/config/Jack2JsonConfiguration.java
@@ -12,6 +12,6 @@ public class Jack2JsonConfiguration {
   @Bean
   public Jackson2JsonMessageConverter jsonMessageConverter() {
     return new Jackson2JsonMessageConverter(
-      new ObjectMapper().registerModule(new JavaTimeModule()));
+        new ObjectMapper().registerModule(new JavaTimeModule()));
   }
 }

--- a/delivery-info-service/src/main/java/com/inbobwetrust/publisher/DeliveryMessagePublisherImpl.java
+++ b/delivery-info-service/src/main/java/com/inbobwetrust/publisher/DeliveryMessagePublisherImpl.java
@@ -1,60 +1,53 @@
 package com.inbobwetrust.publisher;
 
 import com.inbobwetrust.domain.Delivery;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.core.AmqpTemplate;
+import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
+@Component
+@RequiredArgsConstructor
+@Slf4j
 public class DeliveryMessagePublisherImpl implements DeliveryPublisher {
 
   private final AmqpTemplate messageQueue;
 
-  private String shopExchange;
+  private final String shopExchange = "messageQueue.exchange.shop";
 
-  private String agencyExchange;
+  private final String agencyExchange = "messageQueue.exchange.agency";
 
-  public DeliveryMessagePublisherImpl(
-      AmqpTemplate messageQueue, String shopExchange, String agencyExchange) {
-    this.messageQueue = messageQueue;
-    this.shopExchange = shopExchange;
-    this.agencyExchange = agencyExchange;
-  }
-
-  public void setShopExchange(String shopExchange) {
-    this.shopExchange = shopExchange;
-  }
-
-  public void setAgencyExchange(String agencyExchange) {
-    this.agencyExchange = agencyExchange;
-  }
 
   @Override
   public Mono<Delivery> sendAddDeliveryEvent(Delivery delivery) {
     return Mono.just(delivery)
-        .subscribeOn(Schedulers.boundedElastic())
-        .flatMap(this::publishAddDeliveryEvent);
+      .subscribeOn(Schedulers.boundedElastic())
+      .flatMap(this::publishAddDeliveryEvent);
   }
 
   private Mono<Delivery> publishAddDeliveryEvent(Delivery delivery) {
     return Mono.fromCallable(
-        () -> {
-          this.messageQueue.convertAndSend(shopExchange, delivery);
-          return delivery;
-        });
+      () -> {
+        this.messageQueue.convertAndSend(shopExchange, delivery);
+        return delivery;
+      });
   }
 
   @Override
   public Mono<Delivery> sendSetRiderEvent(Delivery delivery) {
     return Mono.just(delivery)
-        .subscribeOn(Schedulers.boundedElastic())
-        .flatMap(this::publishSetRiderEvent);
+      .subscribeOn(Schedulers.boundedElastic())
+      .flatMap(this::publishSetRiderEvent);
   }
 
   private Mono<Delivery> publishSetRiderEvent(Delivery delivery) {
     return Mono.fromCallable(
-        () -> {
-          this.messageQueue.convertAndSend(agencyExchange, delivery);
-          return delivery;
-        });
+      () -> {
+        this.messageQueue.convertAndSend(agencyExchange, delivery);
+        return delivery;
+      });
   }
 }
+

--- a/delivery-info-service/src/main/java/com/inbobwetrust/publisher/DeliveryMessagePublisherImpl.java
+++ b/delivery-info-service/src/main/java/com/inbobwetrust/publisher/DeliveryMessagePublisherImpl.java
@@ -19,35 +19,33 @@ public class DeliveryMessagePublisherImpl implements DeliveryPublisher {
 
   private final String agencyExchange = "messageQueue.exchange.agency";
 
-
   @Override
   public Mono<Delivery> sendAddDeliveryEvent(Delivery delivery) {
     return Mono.just(delivery)
-      .subscribeOn(Schedulers.boundedElastic())
-      .flatMap(this::publishAddDeliveryEvent);
+        .subscribeOn(Schedulers.boundedElastic())
+        .flatMap(this::publishAddDeliveryEvent);
   }
 
   private Mono<Delivery> publishAddDeliveryEvent(Delivery delivery) {
     return Mono.fromCallable(
-      () -> {
-        this.messageQueue.convertAndSend(shopExchange, delivery);
-        return delivery;
-      });
+        () -> {
+          this.messageQueue.convertAndSend(shopExchange, delivery);
+          return delivery;
+        });
   }
 
   @Override
   public Mono<Delivery> sendSetRiderEvent(Delivery delivery) {
     return Mono.just(delivery)
-      .subscribeOn(Schedulers.boundedElastic())
-      .flatMap(this::publishSetRiderEvent);
+        .subscribeOn(Schedulers.boundedElastic())
+        .flatMap(this::publishSetRiderEvent);
   }
 
   private Mono<Delivery> publishSetRiderEvent(Delivery delivery) {
     return Mono.fromCallable(
-      () -> {
-        this.messageQueue.convertAndSend(agencyExchange, delivery);
-        return delivery;
-      });
+        () -> {
+          this.messageQueue.convertAndSend(agencyExchange, delivery);
+          return delivery;
+        });
   }
 }
-

--- a/delivery-info-service/src/main/java/com/inbobwetrust/publisher/DeliveryPublisherImpl.java
+++ b/delivery-info-service/src/main/java/com/inbobwetrust/publisher/DeliveryPublisherImpl.java
@@ -7,12 +7,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
-@Component
 @RequiredArgsConstructor
 @Slf4j
 public class DeliveryPublisherImpl implements DeliveryPublisher {
@@ -26,45 +24,44 @@ public class DeliveryPublisherImpl implements DeliveryPublisher {
 
   public Mono<Delivery> sendAddDeliveryEvent(Delivery delivery) {
     return webClient
-        .post()
-        .uri(proxyShopUrl + "/" + delivery.getShopId())
-        .body(Mono.just(delivery), Delivery.class)
-        .retrieve()
-        .onStatus(
-            HttpStatus::is4xxClientError,
-            clientResponse -> this.handleOn4xxStatus(delivery, clientResponse))
-        .onStatus(
-            HttpStatus::is5xxServerError,
-            serverResponse -> this.handleOn5xxStatus(delivery, serverResponse))
-        .bodyToMono(Delivery.class);
+      .post()
+      .uri(proxyShopUrl + "/" + delivery.getShopId())
+      .body(Mono.just(delivery), Delivery.class)
+      .retrieve()
+      .onStatus(
+        HttpStatus::is4xxClientError,
+        clientResponse -> this.handleOn4xxStatus(delivery, clientResponse))
+      .onStatus(
+        HttpStatus::is5xxServerError,
+        serverResponse -> this.handleOn5xxStatus(delivery, serverResponse))
+      .bodyToMono(Delivery.class);
   }
 
-  @Override
   public Mono<Delivery> sendSetRiderEvent(Delivery delivery) {
     return webClient
-        .post()
-        .uri(proxyAgencyUrl + "/" + delivery.getAgencyId())
-        .body(Mono.just(delivery), Delivery.class)
-        .retrieve()
-        .onStatus(
-            HttpStatus::is4xxClientError,
-            clientResponse -> this.handleOn4xxStatus(delivery, clientResponse))
-        .onStatus(
-            HttpStatus::is5xxServerError,
-            serverResponse -> this.handleOn5xxStatus(delivery, serverResponse))
-        .bodyToMono(Delivery.class);
+      .post()
+      .uri(proxyAgencyUrl + "/" + delivery.getAgencyId())
+      .body(Mono.just(delivery), Delivery.class)
+      .retrieve()
+      .onStatus(
+        HttpStatus::is4xxClientError,
+        clientResponse -> this.handleOn4xxStatus(delivery, clientResponse))
+      .onStatus(
+        HttpStatus::is5xxServerError,
+        serverResponse -> this.handleOn5xxStatus(delivery, serverResponse))
+      .bodyToMono(Delivery.class);
   }
 
   private Mono<? extends Throwable> handleOn5xxStatus(
-      Delivery delivery, ClientResponse serverResponse) {
+    Delivery delivery, ClientResponse serverResponse) {
     log.info("Status code 5XX is : {}", serverResponse.statusCode().value());
     log.info("Error Status 5XX for delivery : {}", delivery);
     return Mono.error(
-        new RelayServerException("Shop operation failed for delivery :     " + delivery));
+      new RelayServerException("Shop operation failed for delivery :     " + delivery));
   }
 
   private Mono<? extends Throwable> handleOn4xxStatus(
-      Delivery delivery, ClientResponse clientResponse) {
+    Delivery delivery, ClientResponse clientResponse) {
     log.info("Status code 4xx is : {}", clientResponse.statusCode().value());
     log.info("Error Status 4XX for delivery : {}", delivery);
     return Mono.error(new RelayClientException("Push Event failed for delivery :     " + delivery));

--- a/delivery-info-service/src/main/java/com/inbobwetrust/service/DeliveryServiceImpl.java
+++ b/delivery-info-service/src/main/java/com/inbobwetrust/service/DeliveryServiceImpl.java
@@ -1,24 +1,23 @@
 package com.inbobwetrust.service;
 
-import static com.inbobwetrust.domain.DeliveryStatus.ACCEPTED;
-import static com.inbobwetrust.domain.DeliveryStatus.PICKED_UP;
-
 import com.inbobwetrust.domain.Delivery;
 import com.inbobwetrust.domain.DeliveryStatus;
 import com.inbobwetrust.exception.DeliveryNotFoundException;
 import com.inbobwetrust.publisher.DeliveryPublisher;
 import com.inbobwetrust.repository.DeliveryRepository;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.retry.RetryBackoffSpec;
 
-@Service
-@Slf4j
+import java.util.Objects;
+
+import static com.inbobwetrust.domain.DeliveryStatus.ACCEPTED;
+import static com.inbobwetrust.domain.DeliveryStatus.PICKED_UP;
+
+@Component
 @RequiredArgsConstructor
 public class DeliveryServiceImpl implements DeliveryService {
   private final DeliveryRepository deliveryRepository;
@@ -32,46 +31,46 @@ public class DeliveryServiceImpl implements DeliveryService {
   @Override
   public Mono<Delivery> acceptDelivery(Delivery delivery) {
     return Mono.just(delivery)
-        .flatMap(DeliveryValidator::statusIsNotNull)
-        .flatMap(DeliveryValidator::statusIsAccepted)
-        .flatMap(DeliveryValidator::pickupTimeIsAfterOrderTime)
-        .flatMap(del -> deliveryRepository.save(delivery))
-        .flatMap(deliveryPublisher::sendSetRiderEvent);
+      .flatMap(DeliveryValidator::statusIsNotNull)
+      .flatMap(DeliveryValidator::statusIsAccepted)
+      .flatMap(DeliveryValidator::pickupTimeIsAfterOrderTime)
+      .flatMap(del -> deliveryRepository.save(delivery))
+      .flatMap(deliveryPublisher::sendSetRiderEvent);
   }
 
   @Override
   public Mono<Delivery> setDeliveryRider(Delivery delivery) {
     return deliveryRepository
-        .findById(delivery.getId())
-        .switchIfEmpty(Mono.error(DeliveryNotFoundException::new))
-        .flatMap(DeliveryValidator::canSetDeliveryRider)
-        .flatMap(del -> deliveryRepository.save(delivery));
+      .findById(delivery.getId())
+      .switchIfEmpty(Mono.error(DeliveryNotFoundException::new))
+      .flatMap(DeliveryValidator::canSetDeliveryRider)
+      .flatMap(del -> deliveryRepository.save(delivery));
   }
 
   @Override
   public Mono<Delivery> setPickedUp(Delivery newDelivery) {
     return deliveryRepository
-        .findById(newDelivery.getId())
-        .switchIfEmpty(Mono.error(DeliveryNotFoundException::new))
-        .flatMap(existingDelivery -> DeliveryValidator.canSetPickUp(existingDelivery, newDelivery))
-        .flatMap(del -> deliveryRepository.save(newDelivery));
+      .findById(newDelivery.getId())
+      .switchIfEmpty(Mono.error(DeliveryNotFoundException::new))
+      .flatMap(existingDelivery -> DeliveryValidator.canSetPickUp(existingDelivery, newDelivery))
+      .flatMap(del -> deliveryRepository.save(newDelivery));
   }
 
   @Override
   public Mono<Delivery> setComplete(Delivery newDelivery) {
     return deliveryRepository
-        .findById(newDelivery.getId())
-        .switchIfEmpty(Mono.error(DeliveryNotFoundException::new))
-        .flatMap(
-            existingDelivery -> DeliveryValidator.canSetComplete(existingDelivery, newDelivery))
-        .flatMap(del -> deliveryRepository.save(newDelivery));
+      .findById(newDelivery.getId())
+      .switchIfEmpty(Mono.error(DeliveryNotFoundException::new))
+      .flatMap(
+        existingDelivery -> DeliveryValidator.canSetComplete(existingDelivery, newDelivery))
+      .flatMap(del -> deliveryRepository.save(newDelivery));
   }
 
   @Override
   public Mono<Delivery> findById(String id) {
     return deliveryRepository
-        .findById(id)
-        .switchIfEmpty(Mono.error(DeliveryNotFoundException::new));
+      .findById(id)
+      .switchIfEmpty(Mono.error(DeliveryNotFoundException::new));
   }
 
   @Override
@@ -87,9 +86,9 @@ public class DeliveryServiceImpl implements DeliveryService {
   @Override
   public Mono<Boolean> isPickedUp(String id) {
     return deliveryRepository
-        .findById(id)
-        .flatMap(del -> Mono.just(del.getDeliveryStatus().equals(PICKED_UP)))
-        .onErrorReturn(NullPointerException.class, false);
+      .findById(id)
+      .flatMap(del -> Mono.just(del.getDeliveryStatus().equals(PICKED_UP)))
+      .onErrorReturn(NullPointerException.class, false);
   }
 
   public static final String MSG_RIDER_ALREADY_SET = "배정된 라이더가 존재합니다. 라이더ID : ";
@@ -116,9 +115,9 @@ public class DeliveryServiceImpl implements DeliveryService {
     private static Mono<Delivery> canSetPickUp(Delivery before, Delivery after) {
       if (!canUpdateStatus(ACCEPTED, before, after)) {
         String message =
-            String.format(
-                "픽업완료로 전환이 불가한 상태입니다.     기존주문상태: %s       요청한주문상태: %s",
-                before.getDeliveryStatus(), after.getDeliveryStatus());
+          String.format(
+            "픽업완료로 전환이 불가한 상태입니다.     기존주문상태: %s       요청한주문상태: %s",
+            before.getDeliveryStatus(), after.getDeliveryStatus());
         return Mono.error(new IllegalStateException(message));
       }
       return Mono.just(after);
@@ -127,16 +126,16 @@ public class DeliveryServiceImpl implements DeliveryService {
     private static Mono<Delivery> canSetComplete(Delivery before, Delivery after) {
       if (!canUpdateStatus(PICKED_UP, before, after)) {
         String message =
-            String.format(
-                "배달완료로 전환이 불가한 상태입니다.     기존주문상태: %s       요청한주문상태: %s",
-                before.getDeliveryStatus(), after.getDeliveryStatus());
+          String.format(
+            "배달완료로 전환이 불가한 상태입니다.     기존주문상태: %s       요청한주문상태: %s",
+            before.getDeliveryStatus(), after.getDeliveryStatus());
         return Mono.error(new IllegalStateException(message));
       }
       return Mono.just(after);
     }
 
     private static boolean canUpdateStatus(
-        DeliveryStatus expectedBeforeStatus, Delivery before, Delivery after) {
+      DeliveryStatus expectedBeforeStatus, Delivery before, Delivery after) {
       boolean statusSameAsExpected = before.getDeliveryStatus().equals(expectedBeforeStatus);
       boolean isNext = before.getDeliveryStatus().getNext().equals(after.getDeliveryStatus());
       return statusSameAsExpected && isNext;
@@ -144,26 +143,26 @@ public class DeliveryServiceImpl implements DeliveryService {
 
     private static Mono<Delivery> monoJustOrError(Delivery after, StringBuilder errorMessage) {
       return errorMessage.length() == 0
-          ? Mono.just(after)
-          : Mono.error(new IllegalArgumentException(errorMessage.toString()));
+        ? Mono.just(after)
+        : Mono.error(new IllegalArgumentException(errorMessage.toString()));
     }
 
     private static Mono<Delivery> statusIsAccepted(Delivery delivery) {
       return delivery.getDeliveryStatus().equals(DeliveryStatus.ACCEPTED)
-          ? Mono.just(delivery)
-          : Mono.error(new IllegalStateException("주문상태가 ACCEPTED가 아닙니다"));
+        ? Mono.just(delivery)
+        : Mono.error(new IllegalStateException("주문상태가 ACCEPTED가 아닙니다"));
     }
 
     private static Mono<Delivery> statusIsNotNull(Delivery delivery) {
       return Objects.isNull(delivery.getDeliveryStatus())
-          ? Mono.error(new IllegalStateException("주문상태가 null 입니다."))
-          : Mono.just(delivery);
+        ? Mono.error(new IllegalStateException("주문상태가 null 입니다."))
+        : Mono.just(delivery);
     }
 
     private static Mono<Delivery> pickupTimeIsAfterOrderTime(Delivery delivery) {
       return delivery.getPickupTime().isAfter(delivery.getOrderTime())
-          ? Mono.just(delivery)
-          : Mono.error(new IllegalStateException("픽업시간은 주문시간 이후여야 합니다."));
+        ? Mono.just(delivery)
+        : Mono.error(new IllegalStateException("픽업시간은 주문시간 이후여야 합니다."));
     }
   }
 }

--- a/delivery-info-service/src/main/resources/application.yml
+++ b/delivery-info-service/src/main/resources/application.yml
@@ -14,8 +14,4 @@ spring:
 hello:
   sha: aaaaaa
   world: Hello World! from Delivery-Info-Service ${hello.sha}.from Here
-
-messageQueue:
-  exchange:
-    shop: rabbit-exchange-shop
-    agency: rabbit-exchange-agency
+  

--- a/delivery-info-service/src/main/resources/application.yml
+++ b/delivery-info-service/src/main/resources/application.yml
@@ -14,4 +14,3 @@ spring:
 hello:
   sha: aaaaaa
   world: Hello World! from Delivery-Info-Service ${hello.sha}.from Here
-  

--- a/delivery-info-service/src/main/resources/application.yml
+++ b/delivery-info-service/src/main/resources/application.yml
@@ -14,3 +14,8 @@ spring:
 hello:
   sha: aaaaaa
   world: Hello World! from Delivery-Info-Service ${hello.sha}.from Here
+
+messageQueue:
+  exchange:
+    shop: rabbit-exchange-shop
+    agency: rabbit-exchange-agency

--- a/delivery-info-service/src/test/java/com/inbobwetrust/publisher/DeliveryMessagePublisherImplTest.java
+++ b/delivery-info-service/src/test/java/com/inbobwetrust/publisher/DeliveryMessagePublisherImplTest.java
@@ -1,26 +1,26 @@
 package com.inbobwetrust.publisher;
 
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.times;
-
 import com.inbobwetrust.domain.Delivery;
-import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.amqp.core.AmqpTemplate;
 import reactor.test.StepVerifier;
 
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+
 @ExtendWith(MockitoExtension.class)
 class DeliveryMessagePublisherImplTest {
 
-  @InjectMocks DeliveryMessagePublisherImpl deliveryPublisher;
+  DeliveryMessagePublisherImpl deliveryPublisher;
 
-  @Mock AmqpTemplate amqpTemplate;
+  AmqpTemplate amqpTemplate;
 
   private final String SHOP_EXCHANGE = "shop-exchange";
 
@@ -28,8 +28,8 @@ class DeliveryMessagePublisherImplTest {
 
   @BeforeEach
   void setUp() {
-    deliveryPublisher.setShopExchange("shop-exchange");
-    deliveryPublisher.setAgencyExchange("agency-exchange");
+    amqpTemplate = Mockito.mock(AmqpTemplate.class);
+    deliveryPublisher = new DeliveryMessagePublisherImpl(amqpTemplate);
   }
 
   @Test
@@ -58,12 +58,12 @@ class DeliveryMessagePublisherImplTest {
 
   private Delivery makeValidDelivery() {
     return Delivery.builder()
-        .shopId("shop1234")
-        .orderId("order-1234")
-        .customerId("customer-1234")
-        .address("서울시 강남구 삼성동 봉은사로 12-41")
-        .phoneNumber("01031583212")
-        .orderTime(LocalDateTime.now())
-        .build();
+      .shopId("shop1234")
+      .orderId("order-1234")
+      .customerId("customer-1234")
+      .address("서울시 강남구 삼성동 봉은사로 12-41")
+      .phoneNumber("01031583212")
+      .orderTime(LocalDateTime.now())
+      .build();
   }
 }


### PR DESCRIPTION
## Overview
- part of issue #198 

## Changes 
- 테스트-신규주문 이벤트
     - 이벤트 발생에 대한 publisher-side IntegrationTest 진행
     - RabbitMQ 도커 컨테이너를 가동시켜서 실제 커넥션 맺고 진행
- `Jackson2JsonMessageConverter` 빈등록
    - AmqpTemplate에서 기존 활용하던 SimpleMessageConverter override 